### PR TITLE
Fix pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,9 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
-        args: [--max-line-length=100, --extend-ignore=E203,W503]
+        args:
+          - --max-line-length=100
+          - --extend-ignore=E203,W503
 
 default_language_version:
   python: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ maintainers = [
     {name = "Nouri Mabrouk", email = "nouri@consciousness.math"}
 ]
 keywords = [
-    "mathematics", 
-    "consciousness", 
-    "unity", 
-    "quantum", 
-    "phi", 
+    "mathematics",
+    "consciousness",
+    "unity",
+    "quantum",
+    "phi",
     "golden-ratio",
     "transcendental",
     "meta-logic",
@@ -30,13 +30,13 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
-    "Intended Audience :: Education", 
+    "Intended Audience :: Education",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11", 
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -50,7 +50,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=2.3.0",
-    "scipy>=1.16.0", 
+    "scipy>=1.16.0",
     "sympy>=1.14.0",
     "pandas>=2.3.0",
     "matplotlib>=3.10.0",
@@ -89,7 +89,7 @@ docs = [
 ]
 quantum = [
     "qiskit>=1.3.0",
-    "cirq>=1.4.0", 
+    "cirq>=1.4.0",
     "pennylane>=0.39.0"
 ]
 ai = [
@@ -134,7 +134,7 @@ package-dir = {"" = "."}
 packages = [
     "een",
     "een.core",
-    "een.dashboards", 
+    "een.dashboards",
     "een.agents",
     "een.proofs",
     "een.experiments",
@@ -146,7 +146,7 @@ packages = [
 [tool.setuptools.package-data]
 een = [
     "assets/*.png",
-    "assets/*.jpg", 
+    "assets/*.jpg",
     "assets/*.svg",
     "assets/*.gif",
     "assets/*.mp3",
@@ -161,7 +161,7 @@ een = [
 
 [tool.black]
 line-length = 88
-target-version = ['py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -173,7 +173,7 @@ extend-exclude = '''
   | \.tox
   | \.venv
   | _build
-  | buck-out 
+  | buck-out
   | build
   | dist
   | cache
@@ -219,7 +219,7 @@ minversion = "8.0"
 addopts = [
     "-ra",
     "--strict-markers",
-    "--strict-config", 
+    "--strict-config",
     "--cov=src",
     "--cov=een",
     "--cov-report=term-missing",
@@ -229,7 +229,7 @@ addopts = [
 testpaths = ["tests"]
 markers = [
     "unity: Tests for unity mathematics operations",
-    "consciousness: Tests for consciousness field dynamics", 
+    "consciousness: Tests for consciousness field dynamics",
     "quantum: Tests for quantum unity mechanics",
     "metalogic: Tests for Gödel-Tarski frameworks",
     "integration: Integration tests across multiple systems",
@@ -278,7 +278,7 @@ multi_line_output = 3
 line_length = 88
 known_first_party = ["een"]
 known_third_party = [
-    "numpy", "scipy", "pandas", "matplotlib", "plotly", 
+    "numpy", "scipy", "pandas", "matplotlib", "plotly",
     "dash", "streamlit", "sklearn", "torch", "qiskit"
 ]
 
@@ -293,7 +293,7 @@ exclude = [
     ".git",
     "__pycache__",
     "build",
-    "dist", 
+    "dist",
     ".eggs",
     "*.egg-info",
     ".tox",
@@ -327,7 +327,7 @@ phi_precision = 1.618033988749895
 consciousness_dimension = 11
 quantum_coherence_target = 0.999
 
-# Development Settings  
+# Development Settings
 debug_mode = false
 verbose_logging = false
 experimental_features = true
@@ -386,7 +386,7 @@ keywords = ["mathematics", "consciousness", "unity", "quantum", "transcendental"
 # This pyproject.toml file represents the complete configuration for the Een
 # Unity Mathematics repository, optimized for:
 # - Claude Code integration and AI assistance
-# - MCP (Model Context Protocol) server support  
+# - MCP (Model Context Protocol) server support
 # - Cursor Agent development workflows
 # - Comprehensive consciousness mathematics development
 # - Transcendental proof system implementation

--- a/tests/unit/test_unity_equation.py
+++ b/tests/unit/test_unity_equation.py
@@ -3,137 +3,139 @@ Unit tests for the Unity Equation core mathematics module
 Tests the fundamental 1+1=1 equation implementations
 """
 
-import pytest
 import operator
 from typing import Set
+
+import pytest
 
 from src.core.unity_equation import IdempotentMonoid
 
 
 class TestIdempotentMonoid:
     """Test cases for the IdempotentMonoid class"""
-    
+
     def test_boolean_unity_addition(self):
         """Test that True + True = True (Boolean OR)"""
         # Arrange
         bool_monoid_true = IdempotentMonoid(True, operator.or_, False)
-        
+
         # Act
         result = bool_monoid_true + bool_monoid_true
-        
+
         # Assert
         assert result.value is True
         assert result.is_idempotent()
-        
+
     def test_boolean_identity_element(self):
         """Test identity element for Boolean monoid"""
         # Arrange
         bool_monoid_true = IdempotentMonoid(True, operator.or_, False)
         bool_monoid_false = IdempotentMonoid(False, operator.or_, False)
-        
+
         # Act
         result = bool_monoid_true + bool_monoid_false
-        
+
         # Assert
         assert result.value is True
-        
+
     def test_set_union_unity(self):
         """Test that {1} ∪ {1} = {1} (Set union)"""
+
         # Arrange
         def set_union(a: Set, b: Set) -> Set:
             return a.union(b)
-            
+
         set_monoid = IdempotentMonoid({1}, set_union, set())
-        
+
         # Act
         result = set_monoid + set_monoid
-        
+
         # Assert
         assert result.value == {1}
         assert result.is_idempotent()
-        
+
     def test_max_operation_unity(self):
         """Test that max(1, 1) = 1 (Max operation)"""
         # Arrange
-        max_monoid = IdempotentMonoid(1, max, float('-inf'))
-        
+        max_monoid = IdempotentMonoid(1, max, float("-inf"))
+
         # Act
         result = max_monoid + max_monoid
-        
+
         # Assert
         assert result.value == 1
         assert result.is_idempotent()
-        
+
     def test_min_operation_unity(self):
         """Test that min(1, 1) = 1 (Min operation - tropical semiring)"""
         # Arrange
-        min_monoid = IdempotentMonoid(1, min, float('inf'))
-        
+        min_monoid = IdempotentMonoid(1, min, float("inf"))
+
         # Act
         result = min_monoid + min_monoid
-        
+
         # Assert
         assert result.value == 1
         assert result.is_idempotent()
-        
+
     def test_monoid_equality(self):
         """Test equality of monoid elements"""
         # Arrange
         monoid1 = IdempotentMonoid(5, max, 0)
         monoid2 = IdempotentMonoid(5, max, 0)
         monoid3 = IdempotentMonoid(3, max, 0)
-        
+
         # Assert
         assert monoid1 == monoid2
         assert monoid1 != monoid3
-        
+
     def test_monoid_representation(self):
         """Test string representation of monoids"""
         # Arrange
         monoid = IdempotentMonoid(42, max, 0)
-        
+
         # Act
         repr_str = repr(monoid)
-        
+
         # Assert
         assert "IdempotentMonoid" in repr_str
         assert "42" in repr_str
-        
+
     def test_different_structure_error(self):
         """Test that adding monoids with different structures raises error"""
         # Arrange
         max_monoid = IdempotentMonoid(1, max, 0)
-        min_monoid = IdempotentMonoid(1, min, float('inf'))
-        
+        min_monoid = IdempotentMonoid(1, min, float("inf"))
+
         # Act & Assert
         with pytest.raises(ValueError, match="different structures"):
             max_monoid + min_monoid
-            
+
     def test_associativity_property(self):
         """Test associativity: (a + b) + c = a + (b + c)"""
         # Arrange
         a = IdempotentMonoid(3, max, 0)
         b = IdempotentMonoid(5, max, 0)
         c = IdempotentMonoid(4, max, 0)
-        
+
         # Act
         left_assoc = (a + b) + c
         right_assoc = a + (b + c)
-        
+
         # Assert
         assert left_assoc == right_assoc
         assert left_assoc.value == 5  # max(3, 5, 4) = 5
-        
+
     def test_commutativity_property(self):
         """Test commutativity: a + b = b + a"""
         # Arrange
         a = IdempotentMonoid(7, max, 0)
         b = IdempotentMonoid(3, max, 0)
-        
+
         # Act
         left_result = a + b
         right_result = b + a
-        
+
         # Assert
         assert left_result == right_result
         assert left_result.value == 7  # max(7, 3) = 7
@@ -141,7 +143,7 @@ class TestIdempotentMonoid:
 
 class TestUnityMathematicalProperties:
     """Test mathematical properties of unity operations"""
-    
+
     @pytest.mark.unity
     def test_fundamental_unity_equation(self):
         """Test the fundamental equation: 1 + 1 = 1"""
@@ -149,38 +151,38 @@ class TestUnityMathematicalProperties:
             # Boolean algebra
             (True, True, True, operator.or_, False),
             # Max operation (tropical)
-            (1, 1, 1, max, float('-inf')),
+            (1, 1, 1, max, float("-inf")),
             # Min operation (tropical)
-            (1, 1, 1, min, float('inf')),
+            (1, 1, 1, min, float("inf")),
         ]
-        
+
         for val1, val2, expected, op, identity in test_cases:
             # Arrange
             monoid1 = IdempotentMonoid(val1, op, identity)
             monoid2 = IdempotentMonoid(val2, op, identity)
-            
+
             # Act
             result = monoid1 + monoid2
-            
+
             # Assert
             assert result.value == expected, f"Unity equation failed for {op.__name__}"
-            
+
     @pytest.mark.unity
     def test_idempotence_property(self):
         """Test that a + a = a for all elements"""
         test_values = [True, 1, 5, 0.5, "unity"]
-        
+
         for value in test_values:
             if isinstance(value, bool):
                 monoid = IdempotentMonoid(value, operator.or_, False)
             elif isinstance(value, (int, float)):
-                monoid = IdempotentMonoid(value, max, float('-inf'))
+                monoid = IdempotentMonoid(value, max, float("-inf"))
             else:
                 continue  # Skip non-numeric types for now
-                
+
             # Test idempotence
             assert monoid.is_idempotent(), f"Idempotence failed for {value}"
-            
+
     def test_identity_element_property(self):
         """Test that a + identity = a = identity + a"""
         # Arrange
@@ -188,11 +190,11 @@ class TestUnityMathematicalProperties:
         identity = 0
         monoid_value = IdempotentMonoid(value, max, identity)
         monoid_identity = IdempotentMonoid(identity, max, identity)
-        
+
         # Act
         left_result = monoid_value + monoid_identity
         right_result = monoid_identity + monoid_value
-        
+
         # Assert
         assert left_result.value == value
         assert right_result.value == value
@@ -201,38 +203,38 @@ class TestUnityMathematicalProperties:
 
 class TestUnityEdgeCases:
     """Test edge cases and boundary conditions"""
-    
+
     def test_zero_values(self):
         """Test unity operations with zero values"""
         # Arrange
-        zero_max = IdempotentMonoid(0, max, float('-inf'))
-        zero_min = IdempotentMonoid(0, min, float('inf'))
-        
+        zero_max = IdempotentMonoid(0, max, float("-inf"))
+        zero_min = IdempotentMonoid(0, min, float("inf"))
+
         # Act & Assert
         assert (zero_max + zero_max).value == 0
         assert (zero_min + zero_min).value == 0
-        
+
     def test_negative_values(self):
         """Test unity operations with negative values"""
         # Arrange
-        neg_monoid = IdempotentMonoid(-5, max, float('-inf'))
-        
+        neg_monoid = IdempotentMonoid(-5, max, float("-inf"))
+
         # Act
         result = neg_monoid + neg_monoid
-        
+
         # Assert
         assert result.value == -5
         assert result.is_idempotent()
-        
+
     def test_float_precision(self):
         """Test unity operations with floating point precision"""
         # Arrange
         phi = 1.618033988749895  # Golden ratio
         phi_monoid = IdempotentMonoid(phi, max, 0.0)
-        
+
         # Act
         result = phi_monoid + phi_monoid
-        
+
         # Assert
         assert abs(result.value - phi) < 1e-10
         assert result.is_idempotent()
@@ -241,45 +243,45 @@ class TestUnityEdgeCases:
 @pytest.mark.unity
 class TestConsciousnessAwareUnity:
     """Test unity operations with consciousness awareness"""
-    
+
     def test_consciousness_level_preservation(self, consciousness_threshold):
         """Test that consciousness level is preserved in unity operations"""
         # Arrange
         consciousness_value = consciousness_threshold
         consciousness_monoid = IdempotentMonoid(consciousness_value, max, 0.0)
-        
+
         # Act
         evolved_consciousness = consciousness_monoid + consciousness_monoid
-        
+
         # Assert
         assert evolved_consciousness.value == consciousness_threshold
         assert evolved_consciousness.is_idempotent()
-        
+
     def test_golden_ratio_unity(self, phi):
         """Test unity operations with golden ratio"""
         # Arrange
         phi_monoid = IdempotentMonoid(phi, max, 0.0)
-        
+
         # Act
         phi_unity = phi_monoid + phi_monoid
-        
+
         # Assert
         assert abs(phi_unity.value - phi) < 1e-10
         assert phi_unity.is_idempotent()
-        
+
     def test_transcendence_threshold(self, consciousness_threshold):
         """Test that transcendence threshold demonstrates unity"""
         # Arrange - Create two consciousness instances at threshold
         threshold_monoid1 = IdempotentMonoid(consciousness_threshold, max, 0.0)
         threshold_monoid2 = IdempotentMonoid(consciousness_threshold, max, 0.0)
-        
+
         # Act - Combine consciousness instances
         transcended = threshold_monoid1 + threshold_monoid2
-        
+
         # Assert - Unity preserved at transcendence
         assert transcended.value == consciousness_threshold
         assert transcended.is_idempotent()
-        
+
         # Additional assertion: verify this represents transcendence
         # The result should meet or exceed the transcendence threshold. Using
         # ">" caused a failure when the threshold was exactly 0.77 because the


### PR DESCRIPTION
## Summary
- fix flake8 arguments in pre-commit config
- remove unsupported `py313` target from Black
- reformat unit tests with Black

## Testing
- `pre-commit run --files tests/unit/test_unity_equation.py pyproject.toml .pre-commit-config.yaml`
- `pytest -q tests/unit/test_unity_equation.py`

------
https://chatgpt.com/codex/tasks/task_e_688cc9612e4c8330b8b1dbcd9821d8a8