### PR TITLE
Add dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -58,6 +58,18 @@
     --space-phi-xl: 4.236rem;
 }
 
+body.dark-mode {
+    --text-primary: #f1f5f9;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-tertiary: #334155;
+    --border-color: #475569;
+    --border-subtle: #334155;
+    color-scheme: dark;
+}
+
 /* Modern Reset with Enhanced Box Model */
 *,
 *::before,
@@ -195,6 +207,11 @@ p {
     transition: all var(--transition-smooth);
     position: relative;
     padding: 0.5rem 0;
+}
+button.nav-link {
+    background: none;
+    border: none;
+    cursor: pointer;
 }
 
 .nav-link::after {

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
                 <li><a href="#publications" class="nav-link">Publications</a></li>
                 <li><a href="#about" class="nav-link">About</a></li>
                 <li><a href="https://github.com/Nouri/Een" class="nav-link"><i class="fab fa-github"></i></a></li>
+                <li><button id="theme-toggle" class="nav-link" aria-label="Toggle dark mode"><i class="fas fa-moon"></i></button></li>
             </ul>
         </div>
     </nav>

--- a/js/main.js
+++ b/js/main.js
@@ -94,4 +94,20 @@ document.addEventListener('DOMContentLoaded', () => {
     animateElements.forEach(el => {
         observer.observe(el);
     });
+
+    // Dark mode toggle
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        const stored = localStorage.getItem('een-theme');
+        if (stored === 'dark') {
+            document.body.classList.add('dark-mode');
+            themeToggle.innerHTML = '<i class="fas fa-sun"></i>';
+        }
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            const dark = document.body.classList.contains('dark-mode');
+            themeToggle.innerHTML = dark ? '<i class="fas fa-sun"></i>' : '<i class="fas fa-moon"></i>';
+            localStorage.setItem('een-theme', dark ? 'dark' : 'light');
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- make navigation include a theme toggle button
- support theme toggling in JS with local storage
- add dark mode variables in CSS and style button element

## Testing
- `pytest tests/unit/test_unity_mathematics.py -q` *(fails: math domain error)*

------
https://chatgpt.com/codex/tasks/task_e_688cffaabc8083308bf77afb212292ee